### PR TITLE
Workaround for S3 file id issue, bump version to 2.1.3 (#35)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "bynder/bynder-php-sdk",
   "description": "Bynder PHP Library",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "keywords": [
     "bynder",
     "sdk",

--- a/src/Bynder/Api/Impl/Upload/FileUploader.php
+++ b/src/Bynder/Api/Impl/Upload/FileUploader.php
@@ -255,7 +255,7 @@ class FileUploader
         ];
         return $this->requestHandler->sendRequestAsync(
             'POST',
-            sprintf('api/v4/upload/%s/', $uploadRequestInfo['s3file']['uploadid']),
+            'api/v4/upload/',
             ['form_params' => $data]
         );
     }
@@ -281,7 +281,7 @@ class FileUploader
         ];
         return $this->requestHandler->sendRequestAsync(
             'POST',
-            sprintf('api/v4/upload/%s/', $uploadRequestInfo['s3file']['uploadid']),
+            'api/v4/upload/',
             ['form_params' => $data]
         );
     }

--- a/tests/AssetBank/FileUploaderTest.php
+++ b/tests/AssetBank/FileUploaderTest.php
@@ -189,7 +189,7 @@ class FileUploaderTest extends TestCase
     {
         return [
             'POST',
-            'api/v4/upload/fakeUploadId/',
+            'api/v4/upload/',
             [
                 'form_params' => [
                     'id' => 'fakeUploadId',
@@ -220,7 +220,7 @@ class FileUploaderTest extends TestCase
     {
         return [
             'POST',
-            'api/v4/upload/fakeUploadId/',
+            'api/v4/upload/',
             [
                 'form_params' => [
                     'id' => 'fakeUploadId',


### PR DESCRIPTION
* Only send uploadId via body

Was sending both via URL and body, where only 1 is needed. Since sending
it via the URL is currently causing issues with certain upload id's,
only send it via the body.

* Bump version to 2.1.3